### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://ancentury.visualstudio.com/2cc547a1-400e-4b53-ad1f-7f0eb62d2fa3/43332d24-2ed7-422a-bed9-b64eb05c8083/_apis/work/boardbadge/1d7574b4-eacf-47f0-9c7e-89e1a930335f)](https://ancentury.visualstudio.com/2cc547a1-400e-4b53-ad1f-7f0eb62d2fa3/_boards/board/t/43332d24-2ed7-422a-bed9-b64eb05c8083/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#5](https://ancentury.visualstudio.com/2cc547a1-400e-4b53-ad1f-7f0eb62d2fa3/_workitems/edit/5). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.